### PR TITLE
move bess connection and monitor thread to Session

### DIFF
--- a/generator/common.py
+++ b/generator/common.py
@@ -127,7 +127,10 @@ class TrafficSpec(object):
 
 
 class Session(object):
-    def __init__(self, port, spec, mode, tx_pipelines, rx_pipelines):
+    """
+    docstring
+    """
+    def __init__(self, port, spec, mode, tx_pipelines, rx_pipelines, bess):
         now = time.time()
         self.__port = port
         self.__spec = spec
@@ -150,6 +153,19 @@ class Session(object):
         self.__rx_pipelines = rx_pipelines
         self.__current_pps = spec.pps
         self.__round = 0
+        self.__bess = bess
+        self.__stopmon = False
+        self.__monitor_thread = None
+
+    def start_monitor(self):
+        if self.__monitor_thread is None:
+            self.__stopmon = False
+            self.__monitor_thread = threading.Thread(target=self.monitor)
+
+    def stop_monitor(self):
+        if self.__monitor_thread is not None:
+            self.__stopmon = True
+            self.__monitor_thread.join()
 
     def port(self):
         return self.__port
@@ -178,8 +194,27 @@ class Session(object):
     def last_check(self):
         return self.__last_chck
 
+    def monitor(self):
+        """
+        Thread to monitor ourselves until told to stop.
+        """
+        while not self.__stopmon:
+            now = time.time()
+            try:
+                self.update_rtt()
+                self.update_port_stats(now)
+
+                self.__bess.pause_all() # ???
+                try:
+                    self.adjust_tx_rate()
+                finally:
+                    self.__bess.resume_all()
+            except bess.BESS.APIError:
+                pass
+            sleep_us(ADJUST_WINDOW_US)
+
     # TODO: allow dynamic tx on mbps
-    def adjust_tx_rate(self, cli):
+    def adjust_tx_rate(self):
         if self.__spec.loss_rate is None or self.__spec.pps is None \
            or self.__round == MAX_ROUNDS:
             return
@@ -210,13 +245,13 @@ class Session(object):
             if tc is None:
                 tx_pipeline.modules[0].update(pps=pps_per_core)
             else:
-                cli.bess.update_tc_params(tc, resource='packet',
-                                          limit={'packet': long(pps_per_core)})
+                self.__bess.update_tc_params(tc, resource='packet',
+                                             limit={'packet': long(pps_per_core)})
 
-    def update_port_stats(self, cli, now=None):
+    def update_port_stats(self, now=None):
         if self.__last_stats is not None:
             self.__last_stats = self.__curr_stats
-        self.__curr_stats = cli.bess.get_port_stats(self.__port)
+        self.__curr_stats = self.__bess.get_port_stats(self.__port)
         if self.__last_stats is None:
             self.__last_stats = self.__curr_stats
         self.__last_check = self.__now
@@ -238,8 +273,8 @@ class Session(object):
             stats[k] /= 1e3 # convert to us
         return stats
 
-    def update_rtt(self, cli):
-        cli.bess.pause_all()
+    def update_rtt(self):
+        self.__bess.pause_all() # ???
         self.__curr_rtt = self._get_rtt()
-        cli.bess.resume_all()
+        self.__bess.resume_all()
         self.__last_check = self.__now

--- a/generator/generator_commands.py
+++ b/generator/generator_commands.py
@@ -590,12 +590,15 @@ def start(cli, port, mode, spec):
 
         cli.bess.resume_all()
 
-    cli.add_session(Session(port, ts, mode, tx_pipes, rx_pipes))
+    sess = Session(port, ts, mode, tx_pipes, rx_pipes, cli.bess)
+    sess.start_monitor()
+    cli.add_session(sess)
 
 
 def _stop(cli, port):
     global available_cores
     sess = cli.remove_session(port)
+    sess.stop_monitor()
     reclaimed_cores = sess.spec().tx_cores + sess.spec().rx_cores
     available_cores = list(sorted(available_cores + reclaimed_cores))
     with cli.bess_lock:


### PR DESCRIPTION
Instead of having a single global thread that monitors
all ports added to a TGENCLI instance, use one thread
per port.

The TGENCLI instance still tracks the sessions (and there
is a minor bug that we will lose an existing session if
we overwrite it with one whose port string is the same;
this will leave a running thread).

This is all totally untested (quick hack sesssion...)