### PR TITLE
Fix pybess import

### DIFF
--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -8,8 +8,8 @@ try:
         print >> sys.stderr, 'BESS_PATH not set'
         sys.exit(1)
     sys.path.insert(1, '%s/bessctl' % bess_path)
-    sys.path.insert(1, '%s/pybess' % bess_path)
-    import bess
+    sys.path.insert(1, '%s' % bess_path)
+    import pybess.bess
     import cli
 except ImportError:
     print >> sys.stderr, 'Cannot import the API module (pybess)'

--- a/generator/cmdline.py
+++ b/generator/cmdline.py
@@ -7,9 +7,9 @@ import tempfile
 import threading
 import time
 
-import bess
+import pybess.bess as bess
 import cli
-from module import *
+from pybess.module import *
 
 import commands as bess_commands
 import generator_commands

--- a/generator/common.py
+++ b/generator/common.py
@@ -3,8 +3,8 @@ import sys
 import threading
 import time
 
-import bess
-from module import *
+import pybess.bess
+from pybess.module import *
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/generator/generator_commands.py
+++ b/generator/generator_commands.py
@@ -20,7 +20,7 @@ import time
 import traceback
 
 import commands as bess_commands
-from module import *
+from pybess.module import *
 
 from common import *
 import modes


### PR DESCRIPTION
Import currently fails with "directory is not a package" error.