### PR TITLE
Add dot1{ad,q} traffic modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@ A traffic generator built on [BESS](https://github.com/NetSys/bess).
 
 First, you'll need to install [BESS](https://github.com/NetSys/bess).
 
+`trafficgen` requires Scapy v2.3.3+ to generate Dot1AD packets.
+However, Scapy v2.3.3 has a breaking IPv6 bug.
+Until v2.3.4 is released, we recommend installing the dev version of Scapy v2.3.3
+which includes the bug fix.
 ```
-$ git clone https://github.com/NetSys/bess.git
-$ bess/build.py
+$ pip install git+https://github.com/secdev/scapy
 ```
 
 Like any other DPDK applications, you need to [set up hugepages](
@@ -17,7 +20,7 @@ http://dpdk.org/doc/guides/linux_gsg/sys_reqs.html#reserving-hugepages-for-dpdk-
 recommended since it can be configured without system reboot and the
 performance difference compared to 1GB ones is negligible.
 
-Afer setting up BESS, bind any NICs you want to generate traffic on to DPDK.
+After setting up BESS, bind any NICs you want to generate traffic on to DPDK.
 Take note of their PCIe addresses.
 
 ## Running

--- a/generator/common.py
+++ b/generator/common.py
@@ -64,6 +64,7 @@ def setup_mclasses(cli, globs):
         'Sink',
         'Timestamp',
         'Update',
+        'VLANPush',
     ]
     for name in MCLASSES:
         if name in globals():

--- a/generator/modes/__init__.py
+++ b/generator/modes/__init__.py
@@ -1,3 +1,5 @@
 from udp import UdpMode
 from flowgen import FlowGenMode
 from http import HttpMode
+from dot1q import Dot1QMode
+from dot1ad import Dot1ADMode

--- a/generator/modes/dot1ad.py
+++ b/generator/modes/dot1ad.py
@@ -1,0 +1,76 @@
+import scapy.all as scapy
+
+from generator.common import TrafficSpec, Pipeline, setup_mclasses
+
+def _build_pkt(spec, size):
+    eth = scapy.Ether(src=spec.src_mac, dst=spec.dst_mac)
+    ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
+    udp = scapy.UDP(sport=10001, dport=10002, chksum=0)
+    pkt = eth/ip/udp
+    payload = ('hello' + '0123456789' * 200)[:size-len(pkt)]
+    return str(pkt/payload)
+
+class Dot1ADMode(object):
+    name = 'dot1ad'
+
+    class Spec(TrafficSpec):
+        def __init__(self, pkt_size=60, num_flows=1, imix=False, **kwargs):
+            self.pkt_size = pkt_size
+            self.imix = imix
+            super(Dot1ADMode.Spec, self).__init__(**kwargs)
+            self.rx_timestamp_offset = 48
+            self.tx_timestamp_offset = 48
+
+
+        def __str__(self):
+            s = super(Dot1ADMode.Spec, self).__str__() + '\n'
+            attrs = [
+                ('pkt_size', lambda x: str(x)),
+                ('imix', lambda x: 'enabled' if x else 'disabled'),
+            ]
+            return s + self._attrs_to_str(attrs, 25)
+
+        def __repr__(self):
+            return self.__str__()
+
+    @staticmethod
+    def setup_tx_pipeline(cli, port, spec):
+        setup_mclasses(cli, globals())
+        if spec.imix:
+            pkt_templates = [
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 1514)
+            ]
+        else:
+            pkt_templates = [_build_pkt(spec, spec.pkt_size)]
+
+        # Setup tx pipeline
+        return Pipeline([
+            Source(),
+            Rewrite(templates=pkt_templates),
+            IPChecksum(),
+            VLANPush(),
+            VLANPush(),
+            RandomUpdate(fields=[{'offset': 14,
+                                   'size': 2,
+                                   'min': 0x0000,
+                                   'max': 0xFFFF}]),
+            RandomUpdate(fields=[{'offset': 18,
+                                   'size': 2,
+                                   'min': 0x0000,
+                                   'max': 0xFFFF}]),
+        ])
+
+    @staticmethod
+    def setup_rx_pipeline(cli, port, spec):
+        setup_mclasses(cli, globals())
+        return Pipeline([Sink()])

--- a/generator/modes/dot1ad.py
+++ b/generator/modes/dot1ad.py
@@ -14,12 +14,17 @@ class Dot1ADMode(object):
     name = 'dot1ad'
 
     class Spec(TrafficSpec):
-        def __init__(self, pkt_size=60, num_flows=1, imix=False, **kwargs):
+        def __init__(self, pkt_size=60, tci1_min=0, tci1_max=0xFFFF,
+                tci2_min=0, tci2_max=0xFFFF, imix=False, **kwargs):
+            super(Dot1ADMode.Spec, self).__init__(**kwargs)
             self.pkt_size = pkt_size
             self.imix = imix
-            super(Dot1ADMode.Spec, self).__init__(**kwargs)
-            self.rx_timestamp_offset = 48
-            self.tx_timestamp_offset = 48
+            self.rx_timestamp_offset = 50
+            self.tx_timestamp_offset = 50
+            self.tci1_min = tci1_min
+            self.tci1_max = tci1_max
+            self.tci2_min = tci2_min
+            self.tci2_max = tci2_max
 
 
         def __str__(self):
@@ -62,12 +67,12 @@ class Dot1ADMode(object):
             VLANPush(),
             RandomUpdate(fields=[{'offset': 14,
                                    'size': 2,
-                                   'min': 0x0000,
-                                   'max': 0xFFFF}]),
+                                   'min': spec.tci1_min,
+                                   'max': spec.tci1_max}]),
             RandomUpdate(fields=[{'offset': 18,
                                    'size': 2,
-                                   'min': 0x0000,
-                                   'max': 0xFFFF}]),
+                                   'min': spec.tci2_min,
+                                   'max': spec.tci2_max}]),
         ])
 
     @staticmethod

--- a/generator/modes/dot1q.py
+++ b/generator/modes/dot1q.py
@@ -14,12 +14,14 @@ class Dot1QMode(object):
     name = 'dot1q'
 
     class Spec(TrafficSpec):
-        def __init__(self, pkt_size=60, imix=False, **kwargs):
+        def __init__(self, pkt_size=60, tci_min=0, tci_max=0xFFFF, imix=False, **kwargs):
+            super(Dot1QMode.Spec, self).__init__(**kwargs)
             self.pkt_size = pkt_size
             self.imix = imix
-            super(Dot1QMode.Spec, self).__init__(**kwargs)
             self.rx_timestamp_offset = 46
             self.tx_timestamp_offset = 46
+            self.tci_min = tci_min
+            self.tci_max = tci_max
 
         def __str__(self):
             s = super(Dot1QMode.Spec, self).__str__() + '\n'
@@ -58,10 +60,10 @@ class Dot1QMode(object):
             Rewrite(templates=pkt_templates),
             IPChecksum(),
             VLANPush(),
-            RandomUpdate(fields=[{'offset': 14,
+            RandomUpdate(fields=[{'offset': 18,
                                    'size': 2,
-                                   'min': 0x0000,
-                                   'max': 0xFFFF}]),
+                                   'min': spec.tci_min,
+                                   'max': spec.tci_max}]),
         ])
 
     @staticmethod

--- a/generator/modes/dot1q.py
+++ b/generator/modes/dot1q.py
@@ -1,0 +1,70 @@
+import scapy.all as scapy
+
+from generator.common import TrafficSpec, Pipeline, setup_mclasses
+
+def _build_pkt(spec, size):
+    eth = scapy.Ether(src=spec.src_mac, dst=spec.dst_mac)
+    ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
+    udp = scapy.UDP(sport=10001, dport=10002, chksum=0)
+    pkt = eth/ip/udp
+    payload = ('hello' + '0123456789' * 200)[:size-len(pkt)]
+    return str(pkt/payload)
+
+class Dot1QMode(object):
+    name = 'dot1q'
+
+    class Spec(TrafficSpec):
+        def __init__(self, pkt_size=60, imix=False, **kwargs):
+            self.pkt_size = pkt_size
+            self.imix = imix
+            super(Dot1QMode.Spec, self).__init__(**kwargs)
+            self.rx_timestamp_offset = 46
+            self.tx_timestamp_offset = 46
+
+        def __str__(self):
+            s = super(Dot1QMode.Spec, self).__str__() + '\n'
+            attrs = [
+                ('pkt_size', lambda x: str(x)),
+                ('imix', lambda x: 'enabled' if x else 'disabled')
+            ]
+            return s + self._attrs_to_str(attrs, 25)
+
+        def __repr__(self):
+            return self.__str__()
+
+    @staticmethod
+    def setup_tx_pipeline(cli, port, spec):
+        setup_mclasses(cli, globals())
+        if spec.imix:
+            pkt_templates = [
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 60),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 590),
+                _build_pkt(spec, 1514)
+            ]
+        else:
+            pkt_templates = [_build_pkt(spec, spec.pkt_size)]
+
+        # Setup tx pipeline
+        return Pipeline([
+            Source(),
+            Rewrite(templates=pkt_templates),
+            IPChecksum(),
+            VLANPush(),
+            RandomUpdate(fields=[{'offset': 14,
+                                   'size': 2,
+                                   'min': 0x0000,
+                                   'max': 0xFFFF}]),
+        ])
+
+    @staticmethod
+    def setup_rx_pipeline(cli, port, spec):
+        setup_mclasses(cli, globals())
+        return Pipeline([Sink()])


### PR DESCRIPTION
Dot1ADMode will not run without Scapy 2.3.3+ (needs dot1AD layer).