### PR TITLE
udp: Fix offsets when using vlan.

### DIFF
--- a/generator/modes/udp.py
+++ b/generator/modes/udp.py
@@ -4,20 +4,17 @@ import struct
 
 from generator.common import TrafficSpec, Pipeline, setup_mclasses
 
+
 def atoh(ip):
-      return struct.unpack("!L", socket.inet_aton(ip))[0]
+    return struct.unpack("!L", socket.inet_aton(ip))[0]
 
 
 def _build_pkt(spec, size):
     eth = scapy.Ether(src=spec.src_mac, dst=spec.dst_mac)
     ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
     udp = scapy.UDP(sport=10001, dport=10002, chksum=0)
-    payload = ('hello' + '0123456789' * 200)[:size-len(eth/ip/udp)]
-    pkt = eth
-    if spec.vlan is not None:
-        dot1q = scapy.Dot1Q(vlan=spec.vlan)
-        pkt = pkt/dot1q
-    pkt = pkt/ip/udp/payload
+    payload = ('hello' + '0123456789' * 200)[:size - len(eth / ip / udp)]
+    pkt = eth / ip / udp / payload
     return str(pkt)
 
 
@@ -25,12 +22,22 @@ class UdpMode(object):
     name = 'udp'
 
     class Spec(TrafficSpec):
-        def __init__(self, pkt_size=60, num_flows=1, imix=False, vlan=None, **kwargs):
+
+        def __init__(self, pkt_size=60, num_flows=1, imix=False, vlan=None,
+                     rx_timestamp_offset=0, tx_timestamp_offset=0, **kwargs):
             self.pkt_size = pkt_size
             self.num_flows = num_flows
             self.imix = imix
             self.vlan = vlan
-            super(UdpMode.Spec, self).__init__(**kwargs)
+            if vlan:
+                if not rx_timestamp_offset:
+                    rx_timestamp_offset = 46
+                if not tx_timestamp_offset:
+                    tx_timestamp_offset = 46
+            super(UdpMode.Spec,
+                    self).__init__(rx_timestamp_offset=rx_timestamp_offset,
+                                   tx_timestamp_offset=tx_timestamp_offset,
+                                   **kwargs)
 
         def __str__(self):
             s = super(UdpMode.Spec, self).__str__() + '\n'
@@ -66,20 +73,22 @@ class UdpMode(object):
 
         num_flows = spec.num_flows
         dst_ip = atoh(spec.dst_ip)
-        dst_ip_offset = 30
-        if spec.vlan:
-            dst_ip_offset += 4
 
         # Setup tx pipeline
-        return Pipeline([
+        pipeline = [
             Source(),
             Rewrite(templates=pkt_templates),
-            RandomUpdate(fields=[{'offset': dst_ip_offset,
-                                   'size': 4,
-                                   'min': dst_ip,
-                                   'max': dst_ip + num_flows - 1}]),
+            RandomUpdate(fields=[{'offset': 30,
+                                  'size': 4,
+                                  'min': dst_ip,
+                                  'max': dst_ip + num_flows - 1}]),
             IPChecksum()
-        ])
+        ]
+
+        if spec.vlan:
+            pipeline.append(VLANPush(tci=spec.vlan))
+
+        return Pipeline(pipeline)
 
     @staticmethod
     def setup_rx_pipeline(cli, port, spec):


### PR DESCRIPTION
IPChecksum() operates at a fixed offset, so we need to push the vlan
tag after we do the checksum.  This means that the vlan tag cannot
be generate by scapy, we require a VLANPush module.

By default, the timestamp offsets needs to be pushed 4 bytes forward.