### PR TITLE
Fix for multi-port

### DIFF
--- a/generator/generator_commands.py
+++ b/generator/generator_commands.py
@@ -402,7 +402,8 @@ def _monitor_ports(cli, *ports):
             if len(ports) > 1:
                 print_delta('Total', get_delta(
                     get_total(last.values()),
-                        get_total(now.values())))
+                        get_total(now.values())),
+                    now[port]['timestamp'])
 
             for port in ports:
                 last[port] = now[port]


### PR DESCRIPTION
Needed to update `print_delta` to supply timestamp in the case where
there are multiple ports.