### PR TITLE
Adopt the new Measure module interface

### DIFF
--- a/generator/common.py
+++ b/generator/common.py
@@ -513,14 +513,15 @@ class Session(object):
         for core, rx_pipeline in self.__rx_pipelines.items():
             measure = rx_pipeline.get_module(
                 'trafficgen_measure_c{}'.format(core))
-            now = measure.get_summary()
-            measure.clear()
-            stats['rtt_avg'] += now.latency_avg_ns
-            stats['rtt_med'] += now.latency_50_ns
-            stats['rtt_99'] += now.latency_99_ns
-            stats['jitter_avg'] += now.jitter_avg_ns
-            stats['jitter_med'] += now.jitter_50_ns
-            stats['jitter_99'] += now.jitter_99_ns
+            now = measure.get_summary(clear=True,
+                                      latency_percentiles=[50, 99],
+                                      jitter_percentiles=[50, 99])
+            stats['rtt_avg'] += now.latency.avg_ns
+            stats['rtt_med'] += now.latency.percentile_values_ns[0]
+            stats['rtt_99'] += now.latency.percentile_values_ns[1]
+            stats['jitter_avg'] += now.jitter.avg_ns
+            stats['jitter_med'] += now.jitter.percentile_values_ns[0]
+            stats['jitter_99'] += now.jitter.percentile_values_ns[1]
         for k in stats:
             stats[k] /= len(self.__rx_pipelines.keys())
             stats[k] /= 1e3  # convert to us

--- a/generator/common.py
+++ b/generator/common.py
@@ -528,9 +528,7 @@ class Session(object):
         return stats
 
     def update_rtt(self, ignore=False):
-        self._pause()
         ret = self._get_rtt()
         if not ignore:
             self.__curr_rtt = ret
-        self._resume()
         self.__last_check = self.__now

--- a/generator/generator_commands.py
+++ b/generator/generator_commands.py
@@ -523,6 +523,11 @@ def start(cli, port, mode, spec):
     if tmode is None:
         raise cli.CommandError("Mode %s is invalid" % (mode,))
 
+    if spec is None or spec['src_mac'] == ret.mac_addr:
+        cli.fout.write('NOTE: Port %s may filter out returned packets whose '
+                       'source is still the same as its own MAC address %s\n'
+                       % (port, ret.mac_addr))
+
     # Initialize the pipelines
     if spec is not None:
         ts = tmode.Spec(tx_cores=tx_cores, rx_cores=rx_cores, **spec)


### PR DESCRIPTION
(feel free to ignore the change in `generator/generator_commands.py`. I thought it'd be useful as I spent hours to figure out why packets are not received at the port... but it could be just me)